### PR TITLE
Update __load__.bro

### DIFF
--- a/scripts/__load__.bro
+++ b/scripts/__load__.bro
@@ -1,3 +1,3 @@
-@load policy/protocols/smb
+@load base/protocols/smb
 
 @load ./find_smbv1.bro


### PR DESCRIPTION
I received this warning, so I updated the package based on the information in the error message.

Warning in /opt/bro/share/bro/policy/protocols/smb/__load__.bro, line 1: deprecated script loaded from find_smbv1/__load__.bro:1 "Use '@load base/protocols/smb' instead"

I tested the package and it provided a notice when SMBv1 was observed.